### PR TITLE
OmegaStation Map Updates

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -112,7 +112,7 @@
 "aaC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "AI Core shutters";
+	id = "aicorewindow";
 	name = "AI core shutters"
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -5301,7 +5301,6 @@
 /area/engine/atmos)
 "amj" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -5316,6 +5315,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "amk" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -22541,13 +22541,13 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/science/research)
+/area/science/server)
 "bir" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/science/research)
+/area/science/server)
 "bit" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -22568,7 +22568,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
-/area/science/research)
+/area/science/server)
 "bix" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -22765,7 +22765,7 @@
 	pressure_checks = 0
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/science/research)
+/area/science/server)
 "biV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -22778,7 +22778,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/science/research)
+/area/science/server)
 "biW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -22922,7 +22922,7 @@
 	dir = 8
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/science/research)
+/area/science/server)
 "bjo" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
@@ -22938,7 +22938,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/science/research)
+/area/science/server)
 "bjp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -23076,7 +23076,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
-/area/science/research)
+/area/science/server)
 "bjC" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rdxeno";
@@ -23102,7 +23102,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/server)
 "bjD" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -23179,7 +23179,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/server)
 "bjP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -23256,7 +23256,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/server)
 "bjV" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -23279,7 +23279,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/server)
 "bjX" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -27441,7 +27441,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/server)
 "fsJ" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -28430,7 +28430,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/server)
 "hkn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29214,6 +29214,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"ivG" = (
+/turf/closed/wall,
+/area/science/server)
 "iwV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -30161,7 +30164,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/science/server)
 "kkJ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/poppy{
@@ -32859,7 +32862,7 @@
 	name = "Xenobiology Containment Door"
 	},
 /turf/open/floor/plating,
-/area/science/research)
+/area/science/server)
 "ola" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34609,7 +34612,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/research)
+/area/science/server)
 "qLF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -38999,7 +39002,7 @@
 "tIz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/science/research)
+/area/science/server)
 "tIB" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
 /turf/open/floor/engine,
@@ -39883,7 +39886,7 @@
 	dir = 9
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/science/research)
+/area/science/server)
 "ver" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -40843,13 +40846,13 @@
 	name = "server vent"
 	},
 /obj/machinery/camera{
-	c_tag = "Server Room";
+	c_tag = "R&D Server Room";
 	dir = 2;
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/science/research)
+/area/science/server)
 "wCx" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -81359,9 +81362,9 @@ sLV
 hMm
 bhy
 bio
-wtK
-wtK
-wtK
+ivG
+ivG
+ivG
 qKH
 bio
 bjX

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -28930,6 +28930,10 @@
 	name = "Solar Maintenance APC";
 	pixel_y = -24
 	},
+/obj/machinery/camera{
+	c_tag = "Solars Control";
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars)
 "iaZ" = (
@@ -30472,6 +30476,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"kNc" = (
+/obj/machinery/camera{
+	c_tag = "Solars External";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/turf/open/space/basic,
+/area/space)
 "kNM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -35483,6 +35495,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"sjf" = (
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars)
 "sjl" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -60499,7 +60518,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+kNc
 akX
 aaa
 ahE
@@ -62298,7 +62317,7 @@ aad
 aad
 aaa
 anL
-apn
+sjf
 apn
 iaJ
 arr


### PR DESCRIPTION
## About The Pull Request

Switched out Gloves in primary tool storage, added a light in the Solar control room, fixed area marking on R&D Server room, and fixed the shutter controls on AI Core

## Why It's Good For The Game

Map improvements

## Changelog
:cl:
add: Added light in Solar control room on Omega Station
tweak: Corrected area marking on R&D Server room for Omega Station
balance: Replaced insulated gloves with budget insulated gloved on Omega Station Primary Tool Storage
fix: fixed AI Core Shutter control on Omega Station
/:cl: