### PR TITLE
OmegaStation Cargo/Tcomms Updates

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -40268,9 +40268,7 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "vBU" = (
-/obj/machinery/telecomms/message_server{
-	network = "tcommsat"
-	},
+/obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "vCj" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1922,9 +1922,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ael" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1939,16 +1936,6 @@
 	dir = 4
 	},
 /mob/living/simple_animal/sloth/citrus,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aem" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeo" = (
@@ -2145,6 +2132,9 @@
 	dir = 5;
 	id = "cargoload"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aeH" = (
@@ -2152,7 +2142,9 @@
 	dir = 4;
 	id = "cargoload"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -3237,12 +3229,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ahq" = (
-/obj/machinery/firealarm{
-	dir = 1;
+/obj/structure/table,
+/obj/machinery/light_switch{
+	pixel_x = 24;
 	pixel_y = -24
 	},
-/obj/machinery/light,
+/obj/item/stack/package_wrap,
+/obj/item/stack/cable_coil,
+/obj/item/hand_labeler,
 /obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -4118,7 +4116,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ajD" = (
-/obj/machinery/autolathe,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -26
 	},
@@ -7737,7 +7734,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/quartermaster/qm)
+/area/quartermaster/storage)
 "atg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -8338,9 +8335,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -9717,6 +9711,9 @@
 /area/quartermaster/storage)
 "ayH" = (
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ayI" = (
@@ -9726,6 +9723,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11372,7 +11372,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aDP" = (
@@ -11810,25 +11809,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aEW" = (
-/obj/structure/table,
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
-	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = 28
+	pixel_x = 27
 	},
-/obj/item/stack/package_wrap,
-/obj/item/stack/cable_coil,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aFb" = (
@@ -28970,8 +28954,8 @@
 	pixel_y = -26
 	},
 /obj/machinery/computer/security/hos{
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
@@ -29191,6 +29175,9 @@
 "irG" = (
 /turf/open/floor/plating,
 /area/science/storage)
+"ist" = (
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "iuA" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
@@ -29251,6 +29238,10 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/primary/port)
+"iyz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "izN" = (
 /turf/closed/mineral/random/labormineral,
 /area/science/test_area)
@@ -31012,6 +31003,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"lza" = (
+/obj/machinery/rnd/bepis,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "lze" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
@@ -34905,9 +34900,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "rkJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -36098,6 +36090,9 @@
 "sEc" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "sEl" = (
@@ -40662,6 +40657,21 @@
 "weW" = (
 /turf/open/floor/plating,
 /area/science/test_area)
+"wfa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "wfA" = (
 /turf/closed/wall,
 /area/medical/virology)
@@ -40876,6 +40886,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/medical/psychology)
+"wzX" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "wAb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
@@ -41310,9 +41324,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "xdM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -82133,12 +82144,12 @@ aad
 aad
 aad
 aad
-aqZ
-aqZ
+asc
+asc
 asc
 asc
 atf
-asc
+aDP
 avb
 awg
 bxF
@@ -82390,16 +82401,16 @@ aad
 aac
 aac
 aad
-aad
-aad
 asc
 asb
 atg
 hVg
+wzX
+wzX
 avc
 awh
 awS
-sFP
+wfa
 sEc
 azG
 aAM
@@ -82647,12 +82658,12 @@ aaa
 aaa
 aad
 aad
-aad
-aad
 asc
 mTL
 ath
 dyX
+iyz
+iyz
 avf
 vgF
 sDn
@@ -82904,12 +82915,12 @@ aaa
 aaa
 aaa
 aad
-aad
-aad
 asc
 jtK
 wLM
 asc
+lza
+ist
 ave
 awj
 aCS
@@ -83161,12 +83172,12 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
 asc
 asc
 asc
 asc
+aDP
+aDP
 kOP
 awi
 adV
@@ -83427,7 +83438,7 @@ aDP
 adh
 adn
 bxG
-aem
+adn
 aeH
 aeX
 axP

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1935,7 +1935,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeo" = (
@@ -2135,7 +2134,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeH" = (
 /obj/machinery/conveyor{
@@ -7734,11 +7733,9 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/quartermaster/storage)
+/area/quartermaster/qm)
 "atg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -7747,14 +7744,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "ath" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
 /obj/effect/landmark/start/quartermaster,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "ati" = (
@@ -9418,19 +9411,8 @@
 	},
 /area/crew_quarters/heads/hop)
 "axP" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/multitool{
-	pixel_x = 6
-	},
-/obj/item/pen/red,
+/obj/machinery/rnd/bepis,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "axR" = (
@@ -14427,18 +14409,24 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aMu" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/yellow,
+/obj/item/multitool{
+	pixel_x = 6
+	},
+/obj/item/pen/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /obj/machinery/requests_console{
 	department = "Cargo Office";
 	departmentType = 0;
 	name = "Cargo Office RC";
 	pixel_x = 32
-	},
-/obj/machinery/computer/bounty{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -28011,6 +27999,14 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
+"gvh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "gxc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
@@ -28094,6 +28090,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"gGH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/mob/living/simple_animal/sloth/citrus,
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "gHj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/purple{
@@ -29175,9 +29177,6 @@
 "irG" = (
 /turf/open/floor/plating,
 /area/science/storage)
-"ist" = (
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "iuA" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
@@ -29240,8 +29239,10 @@
 /area/hallway/primary/port)
 "iyz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/item/folder/blue,
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/quartermaster/qm)
 "izN" = (
 /turf/closed/mineral/random/labormineral,
 /area/science/test_area)
@@ -31004,9 +31005,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lza" = (
-/obj/machinery/rnd/bepis,
+/obj/structure/table,
+/obj/item/clipboard,
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/quartermaster/qm)
 "lze" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
@@ -34026,6 +34028,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
+"pRw" = (
+/obj/machinery/computer/cargo{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "pSZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -40893,8 +40901,11 @@
 /area/medical/psychology)
 "wzX" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/quartermaster/qm)
 "wAb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
@@ -82150,7 +82161,7 @@ asc
 asc
 asc
 atf
-aDP
+asc
 avb
 awg
 bxF
@@ -82405,9 +82416,9 @@ aad
 asc
 asb
 atg
+gGH
+wzX
 hVg
-wzX
-wzX
 avc
 awh
 awS
@@ -82656,15 +82667,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aac
 aad
 aad
 asc
 mTL
 ath
+gvh
+iyz
 dyX
-iyz
-iyz
 avf
 vgF
 sDn
@@ -82914,14 +82925,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aac
 aad
 asc
 jtK
+pRw
 wLM
-asc
 lza
-ist
+asc
 ave
 awj
 aCS
@@ -83171,14 +83182,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aac
+aac
 asc
 asc
 asc
 asc
-aDP
-aDP
+asc
+asc
 kOP
 awi
 adV
@@ -83429,8 +83440,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aac
+aac
 aac
 aad
 aad

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -32184,6 +32184,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"nfS" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/server)
 "nfT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -41066,10 +41073,6 @@
 /area/library)
 "wRs" = (
 /obj/machinery/telecomms/receiver/preset_left/birdstation,
-/obj/machinery/airalarm/server{
-	dir = 4;
-	pixel_x = -23
-	},
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "wSw" = (
@@ -64455,7 +64458,7 @@ bsQ
 eyu
 lvt
 pLb
-sFq
+nfS
 sJj
 sLY
 sNk


### PR DESCRIPTION
## About The Pull Request
Moved AutoLathe into cargo itself rather than the foyer to keep it secured.
Added B.E.P.I.S to cargo for experiments
Fixed Atmos setup to prevent the waste loop leaking into the distro loop.
Moves Air Alarm in Tcomms out of the actual server room and into the control room.
Fixed PDA Server

Resolves #40 Resolves #19 Resolves #20 Resolves
## Why It's Good For The Game

These are either general fixes for the map or improvements to update the map with new features of the codebase.

## Changelog
:cl:
add: B.E.P.I.S. added to OmegaStation Cargo
tweak: Expanded QM's office a few blocks north to allow space for B.E.P.I.S. on OmegaStation
balance: Moved Cargo AutoLathe behind Cargo doors for security on OmegaStation
fix: Fixed OmegaStation atmos waste loop from leaking into distribution through improper setup in Cargo
fix: PDA Server is now properly linked on OmegaStation
tweak: Moved AirAlarm in TComms out of server room and into control room on OmegaStation
del: Removed second bounty console in OmegaStation cargo
add: Added an additional Requests console in QM's office on OmegaStation
tweak: Move Citris spawn location to QM's office on OmegaStation
/:cl:

